### PR TITLE
Update ModuleScanner.php

### DIFF
--- a/ModuleInstall/ModuleScanner.php
+++ b/ModuleInstall/ModuleScanner.php
@@ -662,7 +662,8 @@ class ModuleScanner{
         static $md5 = array();
         if (empty($md5) && file_exists('files.md5')) {
             include ('files.md5');
-            $md5 = $md5_string;
+            /* fixed */
+            $md5 = $md5_string_calculated;
         }
         if ($path[0] != '.' || $path[1] != '/') {
             $path = './' . $path;


### PR DESCRIPTION
PHP complained about $md5-string undefined on line 665. changed $md5_string to $md5_string_calculated since it was included from files.md5. Function now returns correctly and php no longer complains.
